### PR TITLE
Make API base URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,9 @@ Cette application React permet de suivre votre alimentation et vos objectifs nut
 - Les graphiques de l'historique permettent désormais de choisir la période (7 jours à un an) et les détails quotidiens sont affichés du plus récent au plus ancien.
 
 Ces fonctionnalités reposent sur l'API publique OpenFoodFacts.
+
+## Configuration
+
+L'URL de base de l'API peut être personnalisée avec la variable d'environnement
+`VITE_API_BASE_URL`. Si elle n'est pas définie, l'application utilisera par
+défaut `http://localhost:3001/api`.

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,6 +1,15 @@
 import { User, DailyLog } from '../types';
 
-const API = 'http://localhost:3001/api';
+// The API base URL can be configured at build time. Vite exposes variables
+// prefixed with `VITE_` through `import.meta.env`, while a Node environment can
+// use `process.env`.
+const API =
+  (typeof import.meta !== 'undefined'
+    ? (import.meta.env as unknown as Record<string, string | undefined>)
+        .VITE_API_BASE_URL
+    : undefined) ||
+  process.env.VITE_API_BASE_URL ||
+  'http://localhost:3001/api';
 
 export async function login(email: string, password: string) {
   const res = await fetch(`${API}/login`, {


### PR DESCRIPTION
## Summary
- read API base URL from `import.meta.env` or `process.env`
- document new `VITE_API_BASE_URL` variable

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68779619571883258ca49f27078d1d56